### PR TITLE
docs: rename WujiHand QT HMI to Wuji Hand HMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey.svg)](https://github.com/wuji-technology/wujihand-qt)
 [![Version](https://img.shields.io/badge/version-v1.1.0--rc2-orange.svg)](https://github.com/wuji-technology/wujihand-qt/releases/tag/v1.1.0-rc2)
 
-[中文](#wuji-hand-hmi-1) | [English](#english)
+[中文](#wuji-hand-hmi-2) | [English](#wuji-hand-hmi-1)
 
 ---
 
-# English
+# Wuji Hand HMI
 
 Cross-platform graphical user interface application for Wuji Hand dexterous hand control and monitoring
 
@@ -149,7 +149,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Wuji Hand 灵巧手控制和监控跨平台图形用户界面应用程序
 
-[中文](#wuji-hand-hmi-1) | [English](#english)
+[中文](#wuji-hand-hmi-2) | [English](#wuji-hand-hmi-1)
 
 ## 项目简介
 


### PR DESCRIPTION
## Summary

Update README to use consistent product naming:
- WujiHand QT HMI → Wuji Hand HMI
- WujiHand QT 上位机 → Wuji Hand HMI 上位机

## Related

- Story: https://project.feishu.cn/uts5wn/story/detail/6636142957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 将项目名称与标题统一为 “Wuji Hand HMI”，中英文命名及章节标签一致。
  * 优化并扩展英文项目描述与“Key Features”条目，中文内容同步更新与措辞统一。
  * 更新章节锚点与链接以反映新命名。
  * 更新系统要求：Windows 指定为 Windows 11 (64-bit)；Linux 明确为 Ubuntu 22.04 LTS / Ubuntu 24.04 LTS (x86_64)。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->